### PR TITLE
RFC: Update README: fix typo in mconf command

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ CROPS easier. Because it's Kconfig based, extending it is trivial.
 How to use
 -----------
 # Create a .config
-config-mconf ./Kconfig
+kconfig-mconf ./Kconfig
 # Generate the Dockerfile
 ./crops_generator.py --kconf .config --docker <containercontext>
 DOCKER_BUILDKIT=1 docker build -t mycrops/<containercontext> <containercontext>


### PR DESCRIPTION
I'm not sure if this is universal but on my Ubuntu 22 build machine this executable is named kconfig-mconf.