### PR TITLE
fix(lib/crops.py): set owner rights after user is created

### DIFF
--- a/lib/crops.py
+++ b/lib/crops.py
@@ -97,9 +97,10 @@ class crops:
     def SetTemplate(self):
         self.d_tempconf = "COPY --chown={c_user}:{c_user} --chmod=755 template.conf /usr/local/bin/ \n".format(c_user=self.c_user)
         self.d_template = "USER root \n"
+        self.d_template_entrypoints = ""
         np_ep_files = []
         for fn in self.entrypointfiles:
-            self.d_template += "COPY --chown={c_user}:{c_user} --chmod=755 {fn} /usr/local/bin/ \n".format(c_user=self.c_user, fn=fn)
+            self.d_template_entrypoints += "COPY --chown={c_user}:{c_user} --chmod=755 {fn} /usr/local/bin/ \n".format(c_user=self.c_user, fn=fn)
             np_ep_files.append("/usr/local/bin/" + fn)
         self.d_entrypoint = "ENTRYPOINT {np_ep_files} \n".format(np_ep_files=np_ep_files).replace("'", '"')
 
@@ -111,6 +112,7 @@ class crops:
         #USER root stage
 
         f.write(self.d_usermod + '\n\n')
+        f.write(self.d_template_entrypoints + '\n')
         f.write(self.d_tc_manager_script + '\n')
         f.write(self.d_packages_setup + '\n')
 


### PR DESCRIPTION
When you do not have the user that should be used inside the container on your buildsystem, then the build will fail with a message like this:

`
STEP 3/14: COPY --chown=poky:poky --chmod=755 02_runbitbake.py /usr/local/bin/ 
Error: building at STEP "COPY --chown=poky:poky --chmod=755 02_runbitbake.py /usr/local/bin/": looking up UID/GID for "poky:poky": determining run uid: user: unknown user error looking up user "poky"
`
Because the user is created after we try to set the new owner and do it with a username instead of the uid, this fails.

I broke the step up and change the file owner after the user is created. :)